### PR TITLE
SEARCH-637: Trim spaces in barcode search

### DIFF
--- a/cdstub/conf/schema.xml
+++ b/cdstub/conf/schema.xml
@@ -8,7 +8,7 @@
   <similarity class="solr.SchemaSimilarityFactory" />
   <field name="added" type="date" indexed="true" stored="false" />
   <field name="artist" type="text" indexed="true" stored="false" />
-  <field name="barcode" type="strip_leading_zeroes" indexed="true" stored="false" omitNorms="true" />
+  <field name="barcode" type="strip_spaces_and_leading_zeroes" indexed="true" stored="false" omitNorms="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
   <field name="discid" type="string" indexed="true" stored="false" required="true" />
   <!-- id needs to be indexed because it's the unique key -->

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -171,8 +171,9 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   <!-- for use with string fields where there can be multiple values -->
   <fieldtype name="string_mult" class="solr.StrField" sortMissingLast="false" positionIncrementGap="1" />
   <!-- Strips leading zeroes from a string -->
-  <fieldType name="strip_leading_zeroes" class="solr.TextField" positionIncrementGap="100">
+  <fieldType name="strip_spaces_and_leading_zeroes" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
+      <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]+)" replacement="" />
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(^[0]+)" replacement="" />
       <tokenizer class="solr.KeywordTokenizerFactory" />
       <filter class="solr.LowerCaseFilterFactory" />

--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -11,7 +11,7 @@
   <field name="artist" type="text_mult" indexed="true" stored="false" multiValued="true" required="true" />
   <field name="artistname" type="text_mult" indexed="true" stored="false" multiValued="true" required="true" />
   <field name="asin" type="lowercase" indexed="true" stored="false" multiValued="true" />
-  <field name="barcode" type="strip_leading_zeroes" indexed="true" stored="false" />
+  <field name="barcode" type="strip_spaces_and_leading_zeroes" indexed="true" stored="false" />
   <field name="catno" type="strip_spaces_and_separators" indexed="true" stored="false" multiValued="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
   <field name="country" type="lowercase" indexed="true" stored="false" multiValued="true" />


### PR DESCRIPTION
## Implement SEARCH-637: Ignore spaces when parsing barcode in search query

It allows to handle search queries such as `barcode:"0 55490 18252 1"` for both CD stubs and releases.
