### PR TITLE
SEARCH-642 (schema): Drop id fields for cdstub and tag

### DIFF
--- a/cdstub/conf/request-params.xml
+++ b/cdstub/conf/request-params.xml
@@ -1,6 +1,6 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
   <str name="fl">score,_store</str>
-  <str name="qf">artist barcode comment id ngram title</str>
+  <str name="qf">artist barcode comment ngram title</str>
   <str name="pf">artist comment title</str>
 </lst>

--- a/cdstub/conf/schema.xml
+++ b/cdstub/conf/schema.xml
@@ -10,9 +10,8 @@
   <field name="artist" type="text" indexed="true" stored="false" />
   <field name="barcode" type="strip_leading_zeroes" indexed="true" stored="false" omitNorms="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
+  <!-- discid needs to be indexed because it's the unique key -->
   <field name="discid" type="string" indexed="true" stored="false" required="true" />
-  <!-- id needs to be indexed because it's the unique key -->
-  <field name="id" type="string" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="title" type="title" indexed="true" stored="false" required="true" />
   <field name="tracks" type="int" indexed="true" stored="false" />

--- a/cdstub/conf/schema.xml
+++ b/cdstub/conf/schema.xml
@@ -10,9 +10,8 @@
   <field name="artist" type="text" indexed="true" stored="false" />
   <field name="barcode" type="strip_spaces_and_leading_zeroes" indexed="true" stored="false" omitNorms="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
+  <!-- discid needs to be indexed because it's the unique key -->
   <field name="discid" type="string" indexed="true" stored="false" required="true" />
-  <!-- id needs to be indexed because it's the unique key -->
-  <field name="id" type="string" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="title" type="title" indexed="true" stored="false" required="true" />
   <field name="tracks" type="int" indexed="true" stored="false" />
@@ -24,5 +23,5 @@
   <copyField source="title" dest="ngram" />
   <copyField source="artist" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
-  <uniqueKey>id</uniqueKey>
-</schema>
+  <uniqueKey>discid</uniqueKey>
+  </schema>

--- a/tag/conf/schema.xml
+++ b/tag/conf/schema.xml
@@ -6,8 +6,7 @@
     cores, and since all avaliable field types are linked to each core (for simplicity) we need to
     enable per-field similarity in all cores -->
   <similarity class="solr.SchemaSimilarityFactory" />
-  <!-- id needs to be indexed because it's the unique key -->
-  <field name="id" type="string" indexed="true" stored="true" required="true" />
+  <!-- tag needs to be indexed because it's the unique key -->
   <field name="tag" type="text" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="_store" type="storefield" indexed="false" stored="true" />


### PR DESCRIPTION
# Problem
SEARCH-642.

These are not the unique identifiers we use and are not exposed.
For cdstub we expose unique discid, for tag unique name.

# Solution
This pull request stops making `id` a searchable field for cdstub and tag.

It also has to be removed it from being submitted by the indexer, see https://github.com/metabrainz/sir/pull/118

# Checklist for author

* [x] Remove the fields from the documentation.

# Action

Deploy this pull request
Deploy https://github.com/metabrainz/sir/pull/118
Rebuild cdstub and tag search indexes
