### PR TITLE
SEARCH-646: Prioritize exact matches for tag search

### DIFF
--- a/tag/conf/request-params.xml
+++ b/tag/conf/request-params.xml
@@ -1,6 +1,6 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
   <str name="fl">score,_store</str>
-  <str name="qf">tag ngram</str>
+  <str name="qf">exactName^10 tag ngram</str>
   <str name="pf">tag</str>
 </lst>

--- a/tag/conf/schema.xml
+++ b/tag/conf/schema.xml
@@ -9,10 +9,12 @@
   <!-- id needs to be indexed because it's the unique key -->
   <field name="id" type="string" indexed="true" stored="true" required="true" />
   <field name="tag" type="text" indexed="true" stored="false" />
+  <field name="exactName" type="lowercase" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="_store" type="storefield" indexed="false" stored="true" />
   <field name="_version_" type="long" indexed="true" stored="true" />
   <copyField source="tag" dest="ngram" />
+  <copyField source="tag" dest="exactName"/>
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>id</uniqueKey>
 </schema>


### PR DESCRIPTION
### Implement SEARCH-646

We want "rock" to appear before "rock heavy rock pop rock punk rock" and all other similarly crappy tags.

See https://stackoverflow.com/questions/29103155/solr-exact-match-boost-over-text-containing-the-exact-match / https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/4751369/