### PR TITLE
MBS-12154: Add a default sort to all cores to break equal score tiebreakers

### DIFF
--- a/annotation/conf/request-params.xml
+++ b/annotation/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="qf">text type name entity</str>
   <str name="mm">2</str>
   <str name="pf">text name</str>
+  <str name="sort">score desc, id asc</str>
 </lst>

--- a/area/conf/request-params.xml
+++ b/area/conf/request-params.xml
@@ -5,4 +5,5 @@
   <str name="pf">alias^1.5 area^2 areaaccent^2.5 comment</str>
   <str name="bq">type:country^2</str>
   <str name="bf">log(sum(ref_count,1))^4</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/artist/conf/request-params.xml
+++ b/artist/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment ngram^0.5 sortname^1.85</str>
   <str name="pf">primary_alias^2 artist^2 artistaccent^2.2 alias^1.75 sortname^1.85 comment</str>
   <str name="bf">log(sum(ref_count,150))^4</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/cdstub/conf/request-params.xml
+++ b/cdstub/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">artist barcode comment id ngram title</str>
   <str name="pf">artist comment title</str>
+  <str name="sort">score desc, id asc</str>
 </lst>

--- a/editor/conf/request-params.xml
+++ b/editor/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">editor id bio ngram</str>
   <str name="pf">bio</str>
+  <str name="sort">score desc, id asc</str>
 </lst>

--- a/event/conf/request-params.xml
+++ b/event/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="qf">alias aid area arid artist^0.5 begin comment end eid event^2 eventaccent ngram pid place^0.5 tag
   type</str>
   <str name="pf">alias area artist comment event eventaccent place tag</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/instrument/conf/request-params.xml
+++ b/instrument/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">alias^1.2 comment description^0.5 iid instrument^2 instrumentaccent ngram tag type</str>
   <str name="pf">alias comment description instrument^2 instrumentaccent tag</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/instrument/conf/request-params.xml
+++ b/instrument/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="bq">type:Family^-1</str>
   <str name="qf">alias^1.2 comment description^0.5 iid instrument^2 instrumentaccent ngram tag type</str>
   <str name="pf">alias comment description instrument^2 instrumentaccent tag</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/label/conf/request-params.xml
+++ b/label/conf/request-params.xml
@@ -5,4 +5,5 @@
   tag</str>
   <str name="pf">alias area comment label^1.5 labelaccent sortname tag</str>
   <str name="bf">log(sum(release_count,1))^2</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/place/conf/request-params.xml
+++ b/place/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">address^0.25 alias area^0.9 comment^0.5 ngram pid place^2 placeaccent type</str>
   <str name="pf">address alias area comment place^2 placeaccent</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/recording/conf/request-params.xml
+++ b/recording/conf/request-params.xml
@@ -5,4 +5,5 @@
   status tag</str>
   <str name="pf">alias^1.2 artistname^1.5 creditname comment^0.8 recording^2 recordingaccent^2.5 release tag^0.5</str>
   <str name="ps">5</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/release-group/conf/request-params.xml
+++ b/release-group/conf/request-params.xml
@@ -5,4 +5,5 @@
   release^1.3 tag</str>
   <str name="pf">alias^1.2 artistname comment^0.5 creditname releasegroup^1.5 releasegroupaccent^2 release^1.3
   tag^0.5</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/release/conf/request-params.xml
+++ b/release/conf/request-params.xml
@@ -5,4 +5,5 @@
   tag</str>
   <str name="pf">alias^1.2 artistname comment^0.5 creditname label^0.5 release^2 releaseaccent^2 tag^0.5
   type^0.75</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/series/conf/request-params.xml
+++ b/series/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">alias^1.5 comment ngram series^2 seriesaccent sid tag type</str>
   <str name="pf">alias^1.5 comment series^2 seriesaccent tag</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/tag/conf/request-params.xml
+++ b/tag/conf/request-params.xml
@@ -3,4 +3,5 @@
   <str name="fl">score,_store</str>
   <str name="qf">tag ngram</str>
   <str name="pf">tag</str>
+  <str name="sort">score desc, id asc</str>
 </lst>

--- a/url/conf/request-params.xml
+++ b/url/conf/request-params.xml
@@ -2,4 +2,5 @@
   <str name="echoParams">explicit</str>
   <str name="fl">score,_store</str>
   <str name="qf">mbid uid url url_ancestor url_descendent ngram</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/work/conf/request-params.xml
+++ b/work/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="qf">alias^1.2 artist comment lang ngram tag work^1.5 workaccent^2</str>
   <str name="pf">alias^1.2 artist comment tag work^1.5 workaccent^2</str>
   <str name="bf">log(sum(recording_count,1))</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>

--- a/work/conf/request-params.xml
+++ b/work/conf/request-params.xml
@@ -4,4 +4,5 @@
   <str name="qf">alias^1.2 artist comment language ngram tag work^1.5 workaccent^2</str>
   <str name="pf">alias^1.2 artist comment tag work^1.5 workaccent^2</str>
   <str name="bf">log(sum(recording_count,1))</str>
+  <str name="sort">score desc, mbid asc</str>
 </lst>


### PR DESCRIPTION
### Fixes [MBS-12154](https://tickets.metabrainz.org/browse/MBS-12154)

In some kinds of searches (such as "release-group arid:[mbid]"), the score of all resulting documents is constant. If there are more documents matching this result than the page size, it becomes difficult to consistently page through the results.
To fix this, add an arbitrary sort after the score to break it in case that it is equal. I just chose the mbid or id for each core, as it's also the primary key and is guaranteed to be in the document and set.

### Testing
I inspected `schema.xml` for each core to see if its primary key was `id` or `mbid`. I think I got them right. I performed a re-import of the whole search engine and the import completed successfully, I need to perform a search on each core to ensure that I got these values correct.

### Deployment steps
We should be able to add this config to the cores without reindexing everything. It would involve shutting down the core, editing the relevant file inside the data directory, and then starting it back up again.