### PR TITLE
solr: reduce queryResultCache autowarmCount from 512 to 64

### DIFF
--- a/common/queryCache.xml
+++ b/common/queryCache.xml
@@ -4,7 +4,7 @@
     class="${mb.queryResultCache.class:solr.CaffeineCache}"
     size="${mb.queryResultCache.size:32768}"
     initialSize="${mb.queryResultCache.initialSize:8192}"
-    autowarmCount="${mb.queryResultCache.autoWarmCount:512}"
+    autowarmCount="${mb.queryResultCache.autoWarmCount:64}"
     maxRamMB="${mb.queryResultCache.maxRamMB:200}"
     maxIdleTime="${mb.queryResultCache.MaxIdleTime:0}"
     async="${mb.queryResultCache.async:true}"


### PR DESCRIPTION
The queryResultCache autowarmCount controls how many queries from the previous searcher's cache are replayed to warm a new searcher. With autoSoftCommit set to 30s, new searchers open frequently, and each warming cycle replays autowarmCount queries per core.

At 512, warming a single recording shard (~20GB index) took over 3 minutes. With 19 cores per node, warming threads piled up faster than they could complete, causing:

- Sustained load averages of 60+ on mb-solrcloud-5
- kswapd consuming 23% CPU from page cache thrashing (warming evicts cache that queries need, and vice versa)
- searcherExecutor threads stuck for hours, with Solr logging 'Timeout waiting for pool to shutdown' errors

The cache hit ratio was only 3-4%, meaning 96% of warming work was wasted. Reducing to 64 immediately dropped CPU usage on the affected node while having negligible impact on cache effectiveness.

This change was already applied at runtime via the Solr Config API on all 16 collections. This commit makes it permanent in the base solrconfig so it survives configset resyncs and new collection creation.