### PR TITLE
Upgrade schema version from 1.5 to 1.7

### DIFF
--- a/_template/_conf/schema.xml
+++ b/_template/_conf/schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This is a template for new cores. -->
-<schema name="[new_entity]" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="[new_entity]" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!--Searchable Fields
   include comma seperated list of searchable fields for reference
   -->

--- a/annotation/conf/schema.xml
+++ b/annotation/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="annotation" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="annotation" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/area/conf/schema.xml
+++ b/area/conf/schema.xml
@@ -21,7 +21,7 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="ref_count" type="int" indexed="true" stored="false" />
+  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
   <!-- The sort name should be in the appropriate form for the alias locale since different
     languages sort names differently.  Thus sortname is multiValued. -->
   <field name="sortname" type="text" indexed="true" stored="false" multiValued="true" />

--- a/area/conf/schema.xml
+++ b/area/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="area" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="area" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -24,7 +24,7 @@
   <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="ref_count" type="int" indexed="true" stored="false" />
+  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
   <field name="sortname" type="text" indexed="true" stored="false" required="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="artist" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="artist" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/cdstub/conf/schema.xml
+++ b/cdstub/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="cdstub" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="cdstub" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -2,15 +2,15 @@
 Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
 -->
 <types>
-  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" />
-  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" />
-  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" />
-  <fieldType name="storefield" class="solr.StrField" />
+  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="true" />
+  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="true" />
+  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="true" />
+  <fieldType name="storefield" class="solr.StrField" docValues="false" />
   <fieldType name="storefieldmv" class="solr.StrField" docValues="true" />
-  <fieldType name="bool" class="solr.BoolField" />
+  <fieldType name="bool" class="solr.BoolField" docValues="true" />
   <fieldType name="date" class="solr.DateRangeField" sortMissingLast="false" />
-  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" />
-  <fieldType name="float" class="solr.FloatPointField" />
+  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
   <!-- A general text field that has reasonable, generic
          cross-language defaults
 

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -2,15 +2,15 @@
 Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
 -->
 <types>
-  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="true" />
-  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="true" />
-  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="true" />
+  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="false" />
+  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="false" />
+  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="false" />
   <fieldType name="storefield" class="solr.StrField" docValues="false" />
   <fieldType name="storefieldmv" class="solr.StrField" docValues="true" />
-  <fieldType name="bool" class="solr.BoolField" docValues="true" />
+  <fieldType name="bool" class="solr.BoolField" docValues="false" />
   <fieldType name="date" class="solr.DateRangeField" sortMissingLast="false" />
-  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
-  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
+  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="false" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="false" />
   <!-- A general text field that has reasonable, generic
          cross-language defaults
 
@@ -234,4 +234,6 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
       <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
     </analyzer>
   </fieldType>
+  <!-- IntPointField with docValues enabled for use in boost functions -->
+  <fieldType name="int_dv" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
 </types>

--- a/editor/conf/schema.xml
+++ b/editor/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="editor" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="editor" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/event/conf/schema.xml
+++ b/event/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="event" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="event" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/instrument/conf/schema.xml
+++ b/instrument/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="instrument" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="instrument" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="label" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="label" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -22,7 +22,7 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="release_count" type="int" indexed="true" stored="false" />
+  <field name="release_count" type="int_dv" indexed="true" stored="false" />
   <field name="sortname" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />

--- a/place/conf/schema.xml
+++ b/place/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="place" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="place" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/recording/conf/schema.xml
+++ b/recording/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="recording" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="recording" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/release-group/conf/schema.xml
+++ b/release-group/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="release-group" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="release-group" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="release" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="release" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/series/conf/schema.xml
+++ b/series/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="series" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="series" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/tag/conf/schema.xml
+++ b/tag/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="tag" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="tag" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/url/conf/schema.xml
+++ b/url/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="url" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="url" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!--Searchable Fields
   mbid, relationtype, targetid, targettype, uid, url, urls, url_ancestor, url_descendent
   -->

--- a/work/conf/schema.xml
+++ b/work/conf/schema.xml
@@ -16,7 +16,7 @@
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="recording" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="recording_count" type="int" indexed="true" stored="false" />
+  <field name="recording_count" type="int_dv" indexed="true" stored="false" />
   <field name="rid" type="mbid" indexed="true" stored="false" multiValued="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />

--- a/work/conf/schema.xml
+++ b/work/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="work" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="work" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several


### PR DESCRIPTION
#### [Changes](https://github.com/apache/solr/blob/main/solr/server/solr/configsets/_default/conf/managed-schema.xml#L58): 

> 1.6: useDocValuesAsStored defaults to true.
> 1.7: docValues defaults to true, uninvertible defaults to false.

Disabled `docValues` on primitive fields.
Added `int_dv` field type with `docValues` enabled for integer fields used in boost function, since `uninvertible` is disabled. 

#### Testing:
I rebuilt  `mb-solr` image with the new schema and removed the search container and its volumes, then rebuilt and reindexed it (with the sample dump).  Everything seems to be working fine, disk usage remains roughly same as before and JVM heap memory has reduced slightly.