### PR TITLE
Add flattened fields, Remove store field and Add a new XML Writer

### DIFF
--- a/_template/_conf/schema.xml
+++ b/_template/_conf/schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This is a template for new cores. -->
-<schema name="[new_entity]" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="[new_entity]" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!--Searchable Fields
   include comma seperated list of searchable fields for reference
   -->

--- a/annotation/conf/schema.xml
+++ b/annotation/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="annotation" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="annotation" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/area/conf/schema.xml
+++ b/area/conf/schema.xml
@@ -21,7 +21,7 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="ref_count" type="int" indexed="true" stored="false" />
+  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
   <!-- The sort name should be in the appropriate form for the alias locale since different
     languages sort names differently.  Thus sortname is multiValued. -->
   <field name="sortname" type="text" indexed="true" stored="false" multiValued="true" />

--- a/area/conf/schema.xml
+++ b/area/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="area" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="area" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/artist/conf/request-params.xml
+++ b/artist/conf/request-params.xml
@@ -1,6 +1,6 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
-  <str name="fl">score,_store</str>
+  <str name="fl">score, *</str>
   <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment ngram^0.5 sortname^1.85</str>
   <str name="pf">primary_alias^2 artist^2 artistaccent^2.2 alias^1.75 sortname^1.85 comment</str>
   <str name="bf">log(sum(ref_count,150))^4</str>

--- a/artist/conf/request-params.xml
+++ b/artist/conf/request-params.xml
@@ -1,7 +1,8 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
   <str name="fl">score, *</str>
-  <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment ngram^0.5 sortname^1.85</str>
+  <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment edge-ngram^0.5
+    sortname^1.85</str>
   <str name="pf">primary_alias^2 artist^2 artistaccent^2.2 alias^1.75 sortname^1.85 comment</str>
   <str name="bf">log(sum(ref_count,150))^4</str>
 </lst>

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -1,84 +1,85 @@
 <?xml version="1.0"?>
 <schema name="artist" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
-    <!-- link to fieldType definitions for all cores-->
-    <xi:include href="common/fieldtypes.xml" />
-    <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several
+  <!-- link to fieldType definitions for all cores-->
+  <xi:include href="common/fieldtypes.xml" />
+  <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several
     cores, and since all avaliable field types are linked to each core (for simplicity) we need to
-    enable per-field similarity in all cores -->
-    <similarity class="solr.SchemaSimilarityFactory" />
-    <field name="arid" type="mbid" indexed="true" stored="false" />
-    <field name="artist" type="text" indexed="true" stored="true" />
-    <field name="artistaccent" type="keep_accents" indexed="true" stored="false" />
-    <field name="begin" type="date" indexed="true" stored="true" />
-    <field name="end" type="date" indexed="true" stored="true" />
-    <field name="comment" type="text" indexed="true" stored="true" />
-    <field name="ended" type="bool" indexed="true" stored="true" />
-    <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-    <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-    <field name="ref_count" type="int_dv" indexed="true" stored="false" />
-    <field name="sortname" type="text" indexed="true" stored="true" required="true" />
+  enable per-field similarity in all cores -->
+  <similarity class="solr.SchemaSimilarityFactory" />
 
-    <field name="alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
-    <field name="primary_alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
-    <field name="alias_json" type="storefield" indexed="false" stored="true" multiValued="true" />
+  <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
+  <field name="artist" type="text" indexed="true" stored="true" />
+  <field name="sortname" type="text" indexed="true" stored="true" required="true" />
 
-    <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />
-    <field name="area_name" type="string" indexed="false" stored="true" />
-    <field name="area_gid" type="mbid" indexed="false" stored="true" />
-    <field name="area_aliases_name" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="area_begindate" type="string" indexed="false" stored="true" />
-    <field name="area_enddate" type="string" indexed="false" stored="true" />
-    <field name="area_ended" type="bool" indexed="false" stored="true" />
-    <field name="area_type_gid" type="mbid" indexed="false" stored="true" />
-    <field name="area_type_name" type="string" indexed="false" stored="true" />
-    <field name="country" type="lowercase" indexed="true" stored="true" omitNorms="true"
-        omitTermFreqAndPositions="true" />
+  <field name="comment" type="text" indexed="true" stored="true" />
 
-    <field name="beginarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
-    <field name="beginarea_name" type="string" indexed="false" stored="true" />
-    <field name="beginarea_gid" type="mbid" indexed="false" stored="true" />
-    <field name="beginarea_aliases_name" type="string" indexed="false" stored="true"
-        multiValued="true" />
-    <field name="beginarea_begindate" type="string" indexed="false" stored="true" />
-    <field name="beginarea_enddate" type="string" indexed="false" stored="true" />
-    <field name="beginarea_ended" type="bool" indexed="false" stored="true" />
-    <field name="beginarea_type_gid" type="mbid" indexed="false" stored="true" />
-    <field name="beginarea_type_name" type="string" indexed="false" stored="true" />
+  <field name="gender_name" type="lowercase" indexed="true" stored="true" omitNorms="true"
+    omitTermFreqAndPositions="true" />
+  <field name="gender_gid" type="mbid" indexed="false" stored="true" />
 
-    <field name="endarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
-    <field name="endarea_name" type="string" indexed="false" stored="true" />
-    <field name="endarea_gid" type="mbid" indexed="false" stored="true" />
-    <field name="endarea_aliases_name" type="string" indexed="false" stored="true"
-        multiValued="true" />
-    <field name="endarea_begindate" type="string" indexed="false" stored="true" />
-    <field name="endarea_enddate" type="string" indexed="false" stored="true" />
-    <field name="endarea_ended" type="bool" indexed="false" stored="true" />
-    <field name="endarea_type_gid" type="mbid" indexed="false" stored="true" />
-    <field name="endarea_type_name" type="string" indexed="false" stored="true" />
+  <field name="type" type="lowercase" indexed="true" stored="true" omitNorms="true"
+    omitTermFreqAndPositions="true" />
+  <field name="type_gid" type="mbid" indexed="false" stored="true" />
 
-    <field name="gender_name" type="lowercase" indexed="true" stored="true" omitNorms="true"
-        omitTermFreqAndPositions="true" />
-    <field name="gender_gid" type="mbid" indexed="false" stored="true" />
+  <field name="beginarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="beginarea_gid" type="mbid" indexed="false" stored="true" />
+  <field name="beginarea_name" type="string" indexed="false" stored="true" />
+  <field name="beginarea_type" type="string" indexed="false" stored="true" />
+  <field name="beginarea_type_gid" type="mbid" indexed="false" stored="true" />
+  <field name="beginarea_begindate" type="string" indexed="false" stored="true" />
+  <field name="beginarea_enddate" type="string" indexed="false" stored="true" />
+  <field name="beginarea_ended" type="bool" indexed="false" stored="true" />
 
-    <field name="ipi" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
-        multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
-    <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
-        multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
+  <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="area_gid" type="mbid" indexed="false" stored="true" />
+  <field name="area_name" type="string" indexed="false" stored="true" />
+  <field name="area_type" type="string" indexed="false" stored="true" />
+  <field name="area_type_gid" type="mbid" indexed="false" stored="true" />
+  <field name="area_begindate" type="string" indexed="false" stored="true" />
+  <field name="area_enddate" type="string" indexed="false" stored="true" />
+  <field name="area_ended" type="bool" indexed="false" stored="true" />
+  <field name="country" type="lowercase" indexed="true" stored="true" omitNorms="true"
+    omitTermFreqAndPositions="true" />
 
-    <field name="tag_name" type="text_mult" indexed="true" stored="true" multiValued="true" />
-    <field name="tag_count" type="int" indexed="false" stored="true" multiValued="true" />
+  <field name="endarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="endarea_gid" type="mbid" indexed="false" stored="true" />
+  <field name="endarea_name" type="string" indexed="false" stored="true" />
+  <field name="endarea_type" type="string" indexed="false" stored="true" />
+  <field name="endarea_type_gid" type="mbid" indexed="false" stored="true" />
+  <field name="endarea_begindate" type="string" indexed="false" stored="true" />
+  <field name="endarea_enddate" type="string" indexed="false" stored="true" />
+  <field name="endarea_ended" type="bool" indexed="false" stored="true" />
 
-    <field name="type_name" type="lowercase" indexed="true" stored="true" omitNorms="true"
-        omitTermFreqAndPositions="true" />
-    <field name="type_gid" type="mbid" indexed="false" stored="true" />
+  <field name="begin" type="date" indexed="true" stored="true" />
+  <field name="end" type="date" indexed="true" stored="true" />
+  <field name="ended" type="bool" indexed="true" stored="true" />
 
-    <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
+  <field name="alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="primary_alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
+  <field name="alias_json" type="storefield" indexed="false" stored="true" multiValued="true" />
+
+  <field name="ipi" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
+    multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+  <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
+    multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+  <!-- tag_list -->
+  <field name="tag" type="text_mult" indexed="true" stored="true" multiValued="true" />
+  <field name="tag_count" type="int" indexed="false" stored="true" multiValued="true" />
+
+  <field name="arid" type="mbid" indexed="true" stored="false" />
+  <field name="artistaccent" type="keep_accents" indexed="true" stored="false" />
+  <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
+  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
+
+  <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
      or Solr won't start. _version_ and update log are required for SolrCloud. -->
-    <field name="_version_" type="long" indexed="true" stored="true" />
-    <copyField source="artist" dest="artistaccent" />
-    <copyField source="mbid" dest="arid" />
-    <copyField source="artist" dest="ngram" />
-    <copyField source="sortname" dest="ngram" />
-    <!-- field to use to determine and enforce document uniqueness. -->
-    <uniqueKey>mbid</uniqueKey>
+  <field name="_version_" type="long" indexed="true" stored="true" />
+  <copyField source="mbid" dest="arid" />
+  <copyField source="artist" dest="artistaccent" />
+  <copyField source="artist" dest="ngram" />
+  <copyField source="sortname" dest="ngram" />
+  <!-- field to use to determine and enforce document uniqueness. -->
+  <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -18,17 +18,9 @@
     <field name="ref_count" type="int_dv" indexed="true" stored="false" />
     <field name="sortname" type="text" indexed="true" stored="true" required="true" />
 
-    <field name="alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
+    <field name="alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
     <field name="primary_alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
-    <field name="alias_sortname" type="text_mult" indexed="false" stored="true"
-        multiValued="true" />
-    <field name="alias_locale" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="alias_primary_for_locale" type="string" indexed="false" stored="true"
-        multiValued="true" />
-    <field name="alias_begindate" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="alias_enddate" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="alias_type_name" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="alias_type_gid" type="mbid" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_json" type="storefield" indexed="false" stored="true" multiValued="true" />
 
     <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />
     <field name="area_name" type="string" indexed="false" stored="true" />

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -1,42 +1,93 @@
 <?xml version="1.0"?>
 <schema name="artist" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- link to fieldType definitions for all cores-->
-  <xi:include href="common/fieldtypes.xml" />
-  <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several
+    <!-- link to fieldType definitions for all cores-->
+    <xi:include href="common/fieldtypes.xml" />
+    <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several
     cores, and since all avaliable field types are linked to each core (for simplicity) we need to
     enable per-field similarity in all cores -->
-  <similarity class="solr.SchemaSimilarityFactory" />
-  <field name="alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="primary_alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="arid" type="mbid" indexed="true" stored="false" />
-  <field name="artist" type="text" indexed="true" stored="false" />
-  <field name="artistaccent" type="keep_accents" indexed="true" stored="false" />
-  <field name="begin" type="date" indexed="true" stored="false" />
-  <field name="beginarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="comment" type="text" indexed="true" stored="false" />
-  <field name="country" type="lowercase" indexed="true" stored="false" omitNorms="true" />
-  <field name="end" type="date" indexed="true" stored="false" />
-  <field name="endarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="ended" type="bool" indexed="true" stored="false" />
-  <field name="gender" type="lowercase" indexed="true" stored="false" omitNorms="true" />
-  <field name="ipi" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
-  <field name="sortname" type="text" indexed="true" stored="false" required="true" />
-  <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />
-  <!-- Holds data for reponse writer -->
-  <field name="_store" type="storefield" indexed="false" stored="true" multiValued="false" required="false" />
-  <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
+    <similarity class="solr.SchemaSimilarityFactory" />
+    <field name="arid" type="mbid" indexed="true" stored="false" />
+    <field name="artist" type="text" indexed="true" stored="true" />
+    <field name="artistaccent" type="keep_accents" indexed="true" stored="false" />
+    <field name="begin" type="date" indexed="true" stored="true" />
+    <field name="end" type="date" indexed="true" stored="true" />
+    <field name="comment" type="text" indexed="true" stored="true" />
+    <field name="ended" type="bool" indexed="true" stored="true" />
+    <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
+    <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
+    <field name="ref_count" type="int_dv" indexed="true" stored="false" />
+    <field name="sortname" type="text" indexed="true" stored="true" required="true" />
+
+    <field name="alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
+    <field name="primary_alias" type="text_mult" indexed="true" stored="true" multiValued="true" />
+    <field name="alias_sortname" type="text_mult" indexed="false" stored="true"
+        multiValued="true" />
+    <field name="alias_locale" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_primary_for_locale" type="string" indexed="false" stored="true"
+        multiValued="true" />
+    <field name="alias_begindate" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_enddate" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_type_name" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_type_id" type="int" indexed="false" stored="true" multiValued="true" />
+    <field name="alias_type_gid" type="mbid" indexed="false" stored="true" multiValued="true" />
+
+    <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />
+    <field name="area_name" type="string" indexed="false" stored="true" />
+    <field name="area_gid" type="mbid" indexed="false" stored="true" />
+    <field name="area_aliases_name" type="string" indexed="false" stored="true" multiValued="true" />
+    <field name="area_begindate" type="string" indexed="false" stored="true" />
+    <field name="area_enddate" type="string" indexed="false" stored="true" />
+    <field name="area_ended" type="bool" indexed="false" stored="true" />
+    <field name="area_type_gid" type="mbid" indexed="false" stored="true" />
+    <field name="area_type_name" type="string" indexed="false" stored="true" />
+    <field name="country" type="lowercase" indexed="true" stored="true" omitNorms="true"
+        omitTermFreqAndPositions="true" />
+
+    <field name="beginarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
+    <field name="beginarea_name" type="string" indexed="false" stored="true" />
+    <field name="beginarea_gid" type="mbid" indexed="false" stored="true" />
+    <field name="beginarea_aliases_name" type="string" indexed="false" stored="true"
+        multiValued="true" />
+    <field name="beginarea_begindate" type="string" indexed="false" stored="true" />
+    <field name="beginarea_enddate" type="string" indexed="false" stored="true" />
+    <field name="beginarea_ended" type="bool" indexed="false" stored="true" />
+    <field name="beginarea_type_gid" type="mbid" indexed="false" stored="true" />
+    <field name="beginarea_type_name" type="string" indexed="false" stored="true" />
+
+    <field name="endarea" type="text_mult" indexed="true" stored="false" multiValued="true" />
+    <field name="endarea_name" type="string" indexed="false" stored="true" />
+    <field name="endarea_gid" type="mbid" indexed="false" stored="true" />
+    <field name="endarea_aliases_name" type="string" indexed="false" stored="true"
+        multiValued="true" />
+    <field name="endarea_begindate" type="string" indexed="false" stored="true" />
+    <field name="endarea_enddate" type="string" indexed="false" stored="true" />
+    <field name="endarea_ended" type="bool" indexed="false" stored="true" />
+    <field name="endarea_type_gid" type="mbid" indexed="false" stored="true" />
+    <field name="endarea_type_name" type="string" indexed="false" stored="true" />
+
+    <field name="gender_name" type="lowercase" indexed="true" stored="true" omitNorms="true"
+        omitTermFreqAndPositions="true" />
+    <field name="gender_gid" type="mbid" indexed="false" stored="true" />
+
+    <field name="ipi" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
+        multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
+    <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
+        multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+    <field name="tag_name" type="text_mult" indexed="true" stored="true" multiValued="true" />
+    <field name="tag_count" type="int" indexed="false" stored="true" multiValued="true" />
+
+    <field name="type_name" type="lowercase" indexed="true" stored="true" omitNorms="true"
+        omitTermFreqAndPositions="true" />
+    <field name="type_gid" type="mbid" indexed="false" stored="true" />
+
+    <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
      or Solr won't start. _version_ and update log are required for SolrCloud. -->
-  <field name="_version_" type="long" indexed="true" stored="true" />
-  <copyField source="artist" dest="artistaccent" />
-  <copyField source="mbid" dest="arid" />
-  <copyField source="artist" dest="ngram" />
-  <copyField source="sortname" dest="ngram" />
-  <!-- field to use to determine and enforce document uniqueness. -->
-  <uniqueKey>mbid</uniqueKey>
+    <field name="_version_" type="long" indexed="true" stored="true" />
+    <copyField source="artist" dest="artistaccent" />
+    <copyField source="mbid" dest="arid" />
+    <copyField source="artist" dest="ngram" />
+    <copyField source="sortname" dest="ngram" />
+    <!-- field to use to determine and enforce document uniqueness. -->
+    <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -24,7 +24,7 @@
   <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="ref_count" type="int" indexed="true" stored="false" />
+  <field name="ref_count" type="int_dv" indexed="true" stored="false" />
   <field name="sortname" type="text" indexed="true" stored="false" required="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -28,7 +28,6 @@
     <field name="alias_begindate" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="alias_enddate" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="alias_type_name" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="alias_type_id" type="int" indexed="false" stored="true" multiValued="true" />
     <field name="alias_type_gid" type="mbid" indexed="false" stored="true" multiValued="true" />
 
     <field name="area" type="text_mult" indexed="true" stored="false" multiValued="true" />

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="artist" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="artist" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/artist/conf/schema.xml
+++ b/artist/conf/schema.xml
@@ -64,13 +64,12 @@
   <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="true"
     multiValued="true" omitNorms="true" omitTermFreqAndPositions="true" />
 
-  <!-- tag_list -->
   <field name="tag" type="text_mult" indexed="true" stored="true" multiValued="true" />
   <field name="tag_count" type="int" indexed="false" stored="true" multiValued="true" />
 
   <field name="arid" type="mbid" indexed="true" stored="false" />
   <field name="artistaccent" type="keep_accents" indexed="true" stored="false" />
-  <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
+  <field name="edge-ngram" type="edge-ngram" indexed="true" stored="false" multiValued="true" />
   <field name="ref_count" type="int_dv" indexed="true" stored="false" />
 
   <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
@@ -78,8 +77,8 @@
   <field name="_version_" type="long" indexed="true" stored="true" />
   <copyField source="mbid" dest="arid" />
   <copyField source="artist" dest="artistaccent" />
-  <copyField source="artist" dest="ngram" />
-  <copyField source="sortname" dest="ngram" />
+  <copyField source="artist" dest="edge-ngram" />
+  <copyField source="sortname" dest="edge-ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/cdstub/conf/schema.xml
+++ b/cdstub/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="cdstub" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="cdstub" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/common/commonSolrConfig.xml
+++ b/common/commonSolrConfig.xml
@@ -37,4 +37,7 @@
   <queryResponseWriter name="mbjson" class="org.musicbrainz.search.solrwriter.MBJSONWriter">
     <xi:include href="entity-name.xml" />
   </queryResponseWriter>
+  <queryResponseWriter name="flatxml" class="org.musicbrainz.search.solrwriter.MBFlatXMLWriter">
+    <xi:include href="entity-name.xml" />
+  </queryResponseWriter>
 </config>

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -2,15 +2,15 @@
 Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
 -->
 <types>
-  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" />
-  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" />
-  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" />
-  <fieldType name="storefield" class="solr.StrField" />
+  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="true" />
+  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="true" />
+  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="true" />
+  <fieldType name="storefield" class="solr.StrField" docValues="false" />
   <fieldType name="storefieldmv" class="solr.StrField" docValues="true" />
-  <fieldType name="bool" class="solr.BoolField" />
+  <fieldType name="bool" class="solr.BoolField" docValues="true" />
   <fieldType name="date" class="solr.DateRangeField" sortMissingLast="false" />
-  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" />
-  <fieldType name="float" class="solr.FloatPointField" />
+  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
   <!-- A general text field that has reasonable, generic
          cross-language defaults
 

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -2,15 +2,15 @@
 Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
 -->
 <types>
-  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="true" />
-  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="true" />
-  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="true" />
+  <fieldtype name="string" class="solr.StrField" sortMissingLast="false" docValues="false" />
+  <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0" docValues="false" />
+  <fieldType name="mbid" class="solr.UUIDField" omitNorms="true" docValues="false" />
   <fieldType name="storefield" class="solr.StrField" docValues="false" />
   <fieldType name="storefieldmv" class="solr.StrField" docValues="true" />
-  <fieldType name="bool" class="solr.BoolField" docValues="true" />
+  <fieldType name="bool" class="solr.BoolField" docValues="false" />
   <fieldType name="date" class="solr.DateRangeField" sortMissingLast="false" />
-  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
-  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
+  <fieldType name="int" class="solr.IntPointField" sortMissingLast="false" docValues="false" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="false" />
   <!-- A general text field that has reasonable, generic
          cross-language defaults
 
@@ -234,4 +234,6 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
       <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
     </analyzer>
   </fieldType>
+  <!-- IntPointField with docValues enabled for use in boost functions -->
+  <fieldType name="int_dv" class="solr.IntPointField" sortMissingLast="false" docValues="true" />
 </types>

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -168,6 +168,46 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
       <filter class="solr.NGramFilterFactory" minGramSize="3" maxGramSize="10" />
     </analyzer>
   </fieldType>
+
+  <fieldType name="edge-ngram" class="solr.TextField" positionIncrementGap="100" omitNorms="true"
+  omitTermFreqAndPositions="true">
+    <analyzer type="query">
+      <charFilter class="solr.MappingCharFilterFactory"
+        mapping="common/mapping-MBCharEquivToChar.txt" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzWordDelimiterGraphFilterFactory"
+        generateWordParts="1"
+        generateNumberParts="0" catenateWords="0" catenateNumbers="0" catenateAll="0"
+        splitOnCaseChange="0"
+        preserveOriginal="0" splitOnNumerics="0" stemEnglishPossessive="0" />
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
+        id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
+      <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
+        id="Traditional-Simplified" />
+      <filter class="org.apache.lucene.analysis.icu.ICUFoldingFilterFactory" />
+    </analyzer>
+    <analyzer type="index">
+      <charFilter class="solr.MappingCharFilterFactory"
+        mapping="common/mapping-MBCharEquivToChar.txt" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzWordDelimiterGraphFilterFactory"
+        generateWordParts="1"
+        generateNumberParts="0" catenateWords="0" catenateNumbers="0" catenateAll="0"
+        splitOnCaseChange="0"
+        preserveOriginal="0" splitOnNumerics="0" stemEnglishPossessive="0" />
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
+        id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
+      <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
+        id="Traditional-Simplified" />
+      <filter class="org.apache.lucene.analysis.icu.ICUFoldingFilterFactory" />
+      <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="10" />
+    </analyzer>
+  </fieldType>
+
   <!-- for use with string fields where there can be multiple values -->
   <fieldtype name="string_mult" class="solr.StrField" sortMissingLast="false" positionIncrementGap="1" />
   <!-- Strips leading zeroes from a string -->

--- a/editor/conf/schema.xml
+++ b/editor/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="editor" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="editor" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/event/conf/schema.xml
+++ b/event/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="event" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="event" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/instrument/conf/schema.xml
+++ b/instrument/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="instrument" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="instrument" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="label" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="label" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -22,7 +22,7 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
-  <field name="release_count" type="int" indexed="true" stored="false" />
+  <field name="release_count" type="int_dv" indexed="true" stored="false" />
   <field name="sortname" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />

--- a/place/conf/schema.xml
+++ b/place/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="place" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="place" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/recording/conf/schema.xml
+++ b/recording/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="recording" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="recording" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/release-group/conf/schema.xml
+++ b/release-group/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="release-group" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="release-group" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="release" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="release" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/series/conf/schema.xml
+++ b/series/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="series" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="series" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/tag/conf/schema.xml
+++ b/tag/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="tag" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="tag" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several

--- a/url/conf/schema.xml
+++ b/url/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="url" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="url" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!--Searchable Fields
   mbid, relationtype, targetid, targettype, uid, url, urls, url_ancestor, url_descendent
   -->

--- a/work/conf/schema.xml
+++ b/work/conf/schema.xml
@@ -16,7 +16,7 @@
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="recording" type="text_mult" indexed="true" stored="false" multiValued="true" />
-  <field name="recording_count" type="int" indexed="true" stored="false" />
+  <field name="recording_count" type="int_dv" indexed="true" stored="false" />
   <field name="rid" type="mbid" indexed="true" stored="false" multiValued="true" />
   <field name="tag" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />

--- a/work/conf/schema.xml
+++ b/work/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<schema name="work" version="1.5" xmlns:xi="http://www.w3.org/2001/XInclude">
+<schema name="work" version="1.7" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- link to fieldType definitions for all cores-->
   <xi:include href="common/fieldtypes.xml" />
   <!-- To use the custom similarities (ReleaseSimilarity and AliasSimilarity) found in several


### PR DESCRIPTION
Continuation of  #72

In artist schema, This PR: 
Removes `_store` field.

Based on the fields in `SearchArtist` entity in [SIR](https://github.com/metabrainz/sir/blob/931bed48c98eda808b46748d126892cff0fdc08d/sir/schema/__init__.py#L106), 
Stores each flat field directly.

For nested objects, it creates a multi valued `storefield` which stores the JSON string for that object.